### PR TITLE
Fix nhour CI tests

### DIFF
--- a/.github/workflows/GCC.yml
+++ b/.github/workflows/GCC.yml
@@ -78,4 +78,5 @@ jobs:
         mkdir build && cd build
         CC=gcc-11 FC=gfortran-11 cmake .. -DCMAKE_PREFIX_PATH="~/bacio;~/w3emc"
         make -j2
+        sudo apt install faketime # for nhour unit tests
         ctest --output-on-failure --verbose

--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -98,4 +98,5 @@ jobs:
         mkdir build && cd build
         ${{ matrix.compilers }} cmake .. -DCMAKE_PREFIX_PATH="~/bacio;~/w3emc"
         make -j2
+        sudo apt install faketime # for nhour unit tests
         ctest --output-on-failure --verbose

--- a/tests/test_mdate.sh
+++ b/tests/test_mdate.sh
@@ -2,7 +2,7 @@
 set -x
 exe=${1:-mdate}
 
-MDATE_REF_A=$(TZ=UTC date +%Y%m%d%H%M)
+MDATE_REF_A=$(TZ=UT date +%Y%m%d%H%M)
 MDATE_TEST_A=$($exe)
 if [ "$MDATE_REF_A" -eq "$MDATE_TEST_A" ]; then
   pass=A

--- a/tests/test_nhour.sh
+++ b/tests/test_nhour.sh
@@ -3,7 +3,7 @@ set -x
 exe=${1:-nhour}
 
 NHOUR_REF_A=00
-NHOUR_TEST_A=$($exe $(TZ=UT date -d 'today' +%Y%m%d%H))
+NHOUR_TEST_A=$(TZ=UT faketime '20230920 00:00' $exe 2023092000)
 if [ "$NHOUR_REF_A" -eq "$NHOUR_TEST_A" ]; then
   pass=A
 else
@@ -11,7 +11,7 @@ else
 fi
 
 NHOUR_REF_B=27
-NHOUR_TEST_B=$($exe $(TZ=UT date -d 'today +27hours' +%Y%m%d%H))
+NHOUR_TEST_B=$(TZ=UT faketime '20230920 00:00' $exe 2023092103)
 if [ "$NHOUR_REF_B" -eq "$NHOUR_TEST_B" ]; then
   pass=${pass}B
 else


### PR DESCRIPTION
There is an error in the nhour CI tests, specifically, I did not account for the fact that nhour rounds the current time to the nearest hour. This PR adds the use of 'faketime' to spoof the system time to fix the issue and keep things reasonably consistent and simple.

Related to https://github.com/NOAA-EMC/NCEPLIBS-prod_util/issues/24, addendum to #46