### PR TITLE
Remove faketime util from testing

### DIFF
--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -98,5 +98,4 @@ jobs:
         mkdir build && cd build
         ${{ matrix.compilers }} cmake .. -DCMAKE_PREFIX_PATH="~/bacio;~/w3emc"
         make -j2
-        sudo apt install faketime # for nhour unit tests
         ctest --output-on-failure --verbose

--- a/.github/workflows/Linux_versions.yml
+++ b/.github/workflows/Linux_versions.yml
@@ -26,11 +26,6 @@ jobs:
 
     steps:
 
-    - name: install-dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install faketime
-
     - name: cache-bacio
       id: cache-bacio
       uses: actions/cache@v3

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -25,7 +25,7 @@ jobs:
     - name: install-dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install faketime doxygen gcovr
+        sudo apt-get install doxygen gcovr
 
     - name: checkout-bacio
       uses: actions/checkout@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,6 @@ add_subdirectory(ush)
 
 include(CTest)
 if(BUILD_TESTING)
-#  find_program(faketime NAME faketime REQUIRED)
   add_subdirectory(tests)
 endif()
 


### PR DESCRIPTION
This PR removes the faketime util from nhour testing. Instead, it accounts for nhour's rounding to the nearest hour by introducing an offset based on the current system time.

Fixes #53
Fixes #51