### PR TITLE
add `sleep 600` after `scancel $SLURM_JOB_ID` to make sure `err_exit` actually stops a slurm job as expected

### DIFF
--- a/spack/package.py
+++ b/spack/package.py
@@ -24,6 +24,6 @@ class ProdUtil(CMakePackage):
     depends_on("w3emc")
 
     def check(self):
-        with working_dir(self.builder.build_directory):
+        with working_dir(self.build_directory):
             make("test")
     

--- a/ush/err_exit
+++ b/ush/err_exit
@@ -66,4 +66,5 @@ if [ ! -z $PBS_JOBID ]; then
   qdel $PBS_JOBID
 elif [ ! -z $SLURM_JOB_ID ]; then
   scancel $SLURM_JOB_ID
+  sleep 600
 fi

--- a/ush/err_exit
+++ b/ush/err_exit
@@ -66,5 +66,6 @@ if [ ! -z $PBS_JOBID ]; then
   qdel $PBS_JOBID
 elif [ ! -z $SLURM_JOB_ID ]; then
   scancel $SLURM_JOB_ID
+  echo "----- waiting for $SLURM_JOB_ID to be killed -----"
   sleep 600
 fi


### PR DESCRIPTION
As discussed in issue #72 and https://github.com/NOAA-EMC/rrfs-workflow/issues/953,  sometimes, `scancel` does not kill a job immediately and hence the job script runs to the end unexpectedly in this delay period even `err_exit` is called.

One would expect `err_exit` is the last stop of a job script.
This PR adds `sleep 600` after `scancel $SLURM_JOB_ID` so that SLURM has extra time to cancel the job. This makes `err_exit` works more robust as expected without any surprises.