### PR TITLE
Bring in updates from NCO v2.0.15

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,3 +3,4 @@
 add_test(NAME test_nhour COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_nhour.sh ${CMAKE_BINARY_DIR}/sorc/nhour.fd/nhour)
 add_test(NAME test_ndate COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_ndate.sh ${CMAKE_BINARY_DIR}/sorc/ndate.fd/ndate)
 add_test(NAME test_mdate COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_mdate.sh ${CMAKE_BINARY_DIR}/sorc/mdate.fd/mdate)
+add_test(NAME test_err_exit COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_err_exit.sh)

--- a/tests/test_err_exit.sh
+++ b/tests/test_err_exit.sh
@@ -1,0 +1,301 @@
+#!/bin/bash
+
+# Written by Gemini v3.1 Pro. Modified and reviewed by a human.
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_UNDER_TEST=$( realpath "${TEST_DIR}/../ush/err_exit" )
+
+# --- Framework UI ---
+PASSED=0
+FAILED=0
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+pass() {
+    echo -e "${GREEN}PASS:${NC} $1"
+    ((PASSED++))
+}
+
+fail() {
+    echo -e "${RED}FAIL:${NC} $1\n    -> $2\n"
+    ((FAILED++))
+}
+
+# --- Setup & Teardown ---
+setup() {
+    export TEST_TEMP_DIR="$(mktemp -d)"
+    
+    # Unset all potential environment variables to ensure a clean state
+    unset jobid pgm err DATA pgmout SENDECF ECF_HOST ECF_JOBOUT PBS_JOBID ECF_NAME JOBID KILLJOB
+    
+    # Provide a default ECF_NAME so the script doesn't abort early on ${ECF_NAME:?}
+    export ECF_NAME="mock_ecf_job"
+
+    # Mock external commands
+    module() { echo "mock_module $@"; }
+    export -f module
+    
+    timeout() {
+        local duration=$1
+        shift
+        # Allow evaluation of trailing mock commands
+        echo "mock_timeout ${duration}" $("$@")
+    }
+    export -f timeout
+    
+    ecflow_client() { echo "mock_ecflow_client $@"; }
+    export -f ecflow_client
+    
+    ssh() { echo "mock_ssh $@"; }
+    export -f ssh
+    
+    qdel() { echo "mock_qdel $@"; }
+    export -f qdel
+    
+    # Clean up any residual local files
+    rm -f errfile dummy_pgmout
+}
+
+teardown() {
+    rm -rf "$TEST_TEMP_DIR"
+    rm -f errfile dummy_pgmout
+}
+
+# --- Test Cases ---
+
+test_message_construction() {
+    setup
+    export jobid="999"
+    export pgm="data_ingest.sh"
+    export err="127"
+    
+    local output
+    output=$($SCRIPT_UNDER_TEST "Critical failure" 2>&1)
+    
+    if [[ "$output" == *"FATAL ERROR: Critical failure, ERROR IN data_ingest.sh RETURN CODE 127"* ]]; then
+        pass "$FUNCNAME"
+    else
+        fail "$FUNCNAME" "Message construction failed. Output: $output"
+    fi
+    teardown
+}
+
+test_data_warning_when_unset() {
+    setup
+    # DATA is intentionally unset
+    local output
+    output=$($SCRIPT_UNDER_TEST 2>&1)
+    
+    if [[ "$output" == *"WARNING: DATA variable not defined"* ]]; then
+        pass "$FUNCNAME"
+    else
+        fail "$FUNCNAME" "Did not find expected warning. Output: $output"
+    fi
+    teardown
+}
+
+test_ls_when_data_set() {
+    setup
+    export DATA="$TEST_TEMP_DIR"
+    export LMOD_SH_DBG_ON=1
+
+    local output
+    output=$(bash -x $SCRIPT_UNDER_TEST 2>&1)
+   
+    if [[ "$output" == *"ls -ltr $TEST_TEMP_DIR"* ]]; then
+        pass "$FUNCNAME"
+    else
+        fail "$FUNCNAME" "Failed to find 'ls -ltr $TEST_TEMP_DIR' call. Output: "
+        echo "$output"
+    fi
+
+    unset LMOD_SH_DBG_ON
+    teardown
+}
+
+test_errfile_appends_to_pgmout() {
+    setup
+    export pgmout="dummy_pgmout"
+    touch dummy_pgmout
+    echo "Simulated error log entry" > errfile
+    
+    local output
+    output=$($SCRIPT_UNDER_TEST 2>&1)
+    
+    if grep -q "contents of errfile" dummy_pgmout && grep -q "Simulated error log entry" dummy_pgmout; then
+        pass "$FUNCNAME"
+    else
+        fail "$FUNCNAME" "File was not appended correctly."
+    fi
+    teardown
+}
+
+test_sendecf_yes() {
+    setup
+    export SENDECF="YES"
+    export ECF_HOST="my-ecflow-host"
+    export ECF_JOBOUT="/path/to/ecf.out"
+    
+    local output
+    output=$($SCRIPT_UNDER_TEST 2>&1)
+    
+    if [[ "$output" == *"mock_timeout 30 mock_ecflow_client --msg mock_ecf_job: Job UNKNOWN failed"* ]] && \
+       [[ "$output" == *"mock_timeout 30 mock_ssh my-ecflow-host echo"* ]] && \
+       [[ "$output" == *">> $ECF_JOBOUT"* ]]; then
+        pass "$FUNCNAME"
+    else
+        fail "$FUNCNAME" "Mocks were not called properly. Output: $output"
+    fi
+    teardown
+}
+
+test_ecflow_log_no_ecf_jobout() {
+    setup
+    export SENDECF="YES"
+    export ECF_JOBOUT="/path/to/ecf.out"
+
+    local output
+    output=$($SCRIPT_UNDER_TEST 2>&1)
+
+    if [[ "$output" == *"FATAL ERROR Unable to write to ecflow server as either ECF_HOST or ECF_JOBOUT are undefined!!"* ]]; then
+        pass "$FUNCNAME"
+    else
+        fail "$FUNCNAME" "ecFlow log written when ECF_HOST is empty. Output: $output"
+    fi
+    teardown
+}
+
+test_ecflow_log_no_ecf_host() {
+    setup
+    export SENDECF="YES"
+    export ECF_HOST="my-ecflow-host"
+
+    local output
+    output=$($SCRIPT_UNDER_TEST 2>&1)
+
+    if [[ "$output" == *"FATAL ERROR Unable to write to ecflow server as either ECF_HOST or ECF_JOBOUT are undefined!!"* ]]; then
+        pass "$FUNCNAME"
+    else
+        fail "$FUNCNAME" "ecFlow log written when ECF_JOBOUT is empty. Output: $output"
+    fi
+    teardown
+}
+
+test_ecflow_log_no_ecf_jobout_no_ecf_host() {
+    setup
+    export SENDECF="YES"
+
+    local output
+    output=$($SCRIPT_UNDER_TEST 2>&1)
+
+    if [[ "$output" == *"FATAL ERROR Unable to write to ecflow server as either ECF_HOST or ECF_JOBOUT are undefined!!"* ]]; then
+        pass "$FUNCNAME"
+    else
+        fail "$FUNCNAME" "ecFlow log written when ECF_HOST and ECF_JOBOUT are empty. Output: $output"
+    fi
+    teardown
+}
+
+test_kill_via_ecflow_when_no_pbs() {
+    setup
+    # PBS_JOBID is unset
+
+    export SENDECF="YES"
+
+    local output
+    output=$($SCRIPT_UNDER_TEST 2>&1)
+    
+    if [[ "$output" == *"mock_ecflow_client --kill=mock_ecf_job"* ]]; then
+        pass "$FUNCNAME"
+    else
+        fail "$FUNCNAME" "Expected ecflow kill call missing. Output: $output"
+    fi
+    teardown
+}
+
+test_kill_via_ecflow_no_ecf_name() {
+    setup
+
+    export SENDECF="YES"
+    export ECF_HOST="my-ecflow-host"
+    export ECF_JOBOUT="/path/to/ecf.out"
+    export ECF_NAME=""
+    export JOBID="12345.scheduler"
+
+    local output
+    output=$($SCRIPT_UNDER_TEST 2>&1)
+
+    if [[ "$output" == *"FATAL ERROR Unable to kill ecflow job as ECF_NAME variable is not set!!"* ]]; then
+        pass "$FUNCNAME"
+    else
+        fail "$FUNCNAME" "Expected qdel call missing or JOBID not set properly. Output: $output"
+    fi
+    teardown
+}
+
+test_kill_via_qdel_when_pbs_set() {
+    setup
+    export PBS_JOBID="12345.scheduler"
+    
+    local output
+    output=$($SCRIPT_UNDER_TEST 2>&1)
+    
+    if [[ "$output" == *"mock_qdel 12345.scheduler"* ]] && [[ "$output" != *"mock_ecflow_client --kill"* ]]; then
+        pass "$FUNCNAME"
+    else
+        fail "$FUNCNAME" "Expected qdel call missing or ecflow called improperly. Output: $output"
+    fi
+    teardown
+}
+
+test_kill_via_qdel_no_pbs_jobid() {
+    setup
+
+    local output
+    output=$($SCRIPT_UNDER_TEST 2>&1)
+
+    if [[ "$output" == *"Could not find a scheduler command or job ID to kill the current job"* ]] && \
+        [[ "$output" == *"KILLJOB = qdel"* ]] && \
+        echo "$output" | grep -qE "^JOBID   = $" ; then
+        pass "$FUNCNAME"
+    else
+        fail "$FUNCNAME" "Expected failure did not occur when JOBID is empty. Output: $output"
+    fi
+    teardown
+}
+
+# --- Test Runner ---
+
+echo "Starting pure Bash test suite for $SCRIPT_UNDER_TEST..."
+echo "-------------------------------------------------------------"
+
+# Check if target script is executable
+if [ ! -x "$SCRIPT_UNDER_TEST" ]; then
+    echo "Applying executable permissions to $SCRIPT_UNDER_TEST..."
+    chmod +x "$SCRIPT_UNDER_TEST"
+fi
+
+# Execute all tests
+test_message_construction
+test_data_warning_when_unset
+test_ls_when_data_set
+test_errfile_appends_to_pgmout
+test_sendecf_yes
+test_ecflow_log_no_ecf_jobout
+test_ecflow_log_no_ecf_host
+test_ecflow_log_no_ecf_jobout_no_ecf_host
+test_kill_via_ecflow_when_no_pbs
+test_kill_via_ecflow_no_ecf_name
+test_kill_via_qdel_when_pbs_set
+test_kill_via_qdel_no_pbs_jobid
+
+echo "-------------------------------------------------------------"
+echo "Test Run Complete: $PASSED passed, $FAILED failed."
+
+# Return standard exit codes for CI/CD compatibility
+if [ "$FAILED" -ne 0 ]; then
+    exit 1
+else
+    exit 0
+fi 

--- a/tests/test_err_exit.sh
+++ b/tests/test_err_exit.sh
@@ -24,18 +24,22 @@ fail() {
 
 # --- Setup & Teardown ---
 setup() {
+    # Take an optional argument for the scheduler type
+    # Usage: setup [pbs|slurm|lsf]
+
     export TEST_TEMP_DIR="$(mktemp -d)"
-    
+
     # Unset all potential environment variables to ensure a clean state
     unset jobid pgm err DATA pgmout SENDECF ECF_HOST ECF_JOBOUT PBS_JOBID ECF_NAME JOBID KILLJOB
-    
+    unset SLURM_JOB_ID SLURM_SLEEP LSF_JOBID qdel scancel bkill
+
     # Provide a default ECF_NAME so the script doesn't abort early on ${ECF_NAME:?}
     export ECF_NAME="mock_ecf_job"
 
     # Mock external commands
     module() { echo "mock_module $@"; }
     export -f module
-    
+
     timeout() {
         local duration=$1
         shift
@@ -43,16 +47,40 @@ setup() {
         echo "mock_timeout ${duration}" $("$@")
     }
     export -f timeout
-    
+
     ecflow_client() { echo "mock_ecflow_client $@"; }
     export -f ecflow_client
-    
+
     ssh() { echo "mock_ssh $@"; }
     export -f ssh
-    
+
     qdel() { echo "mock_qdel $@"; }
-    export -f qdel
-    
+
+    scancel() { echo "mock_scancel $@"; }
+
+    bkill() { echo "mock_bkill $@"; }
+
+    if [[ $# -gt 0 ]]; then
+        case "$1" in
+            pbs)
+                export PBS_JOBID="12345.scheduler"
+                export -f qdel
+                ;;
+            slurm)
+                export SLURM_JOB_ID="67890"
+                export SLURM_SLEEP="0"
+                export -f scancel
+                ;;
+            lsf)
+                export LSF_JOBID="54321"
+                export -f bkill
+                ;;
+            *)
+                # Do not set any scheduler variables.
+                ;;
+        esac
+    fi
+
     # Clean up any residual local files
     rm -f errfile dummy_pgmout
 }
@@ -60,19 +88,21 @@ setup() {
 teardown() {
     rm -rf "$TEST_TEMP_DIR"
     rm -f errfile dummy_pgmout
+    unset jobid pgm err DATA pgmout SENDECF ECF_HOST ECF_JOBOUT PBS_JOBID ECF_NAME JOBID KILLJOB
+    unset SLURM_JOB_ID SLURM_SLEEP LSF_JOBID qdel scancel bkill
 }
 
 # --- Test Cases ---
 
 test_message_construction() {
-    setup
+    setup pbs
     export jobid="999"
     export pgm="data_ingest.sh"
     export err="127"
-    
+
     local output
     output=$($SCRIPT_UNDER_TEST "Critical failure" 2>&1)
-    
+
     if [[ "$output" == *"FATAL ERROR: Critical failure, ERROR IN data_ingest.sh RETURN CODE 127"* ]]; then
         pass "$FUNCNAME"
     else
@@ -82,11 +112,11 @@ test_message_construction() {
 }
 
 test_data_warning_when_unset() {
-    setup
+    setup pbs
     # DATA is intentionally unset
     local output
     output=$($SCRIPT_UNDER_TEST 2>&1)
-    
+
     if [[ "$output" == *"WARNING: DATA variable not defined"* ]]; then
         pass "$FUNCNAME"
     else
@@ -96,13 +126,13 @@ test_data_warning_when_unset() {
 }
 
 test_ls_when_data_set() {
-    setup
+    setup pbs
     export DATA="$TEST_TEMP_DIR"
     export LMOD_SH_DBG_ON=1
 
     local output
     output=$(bash -x $SCRIPT_UNDER_TEST 2>&1)
-   
+
     if [[ "$output" == *"ls -ltr $TEST_TEMP_DIR"* ]]; then
         pass "$FUNCNAME"
     else
@@ -115,14 +145,14 @@ test_ls_when_data_set() {
 }
 
 test_errfile_appends_to_pgmout() {
-    setup
+    setup pbs
     export pgmout="dummy_pgmout"
     touch dummy_pgmout
     echo "Simulated error log entry" > errfile
-    
+
     local output
     output=$($SCRIPT_UNDER_TEST 2>&1)
-    
+
     if grep -q "contents of errfile" dummy_pgmout && grep -q "Simulated error log entry" dummy_pgmout; then
         pass "$FUNCNAME"
     else
@@ -132,14 +162,14 @@ test_errfile_appends_to_pgmout() {
 }
 
 test_sendecf_yes() {
-    setup
+    setup pbs
     export SENDECF="YES"
     export ECF_HOST="my-ecflow-host"
     export ECF_JOBOUT="/path/to/ecf.out"
-    
+
     local output
     output=$($SCRIPT_UNDER_TEST 2>&1)
-    
+
     if [[ "$output" == *"mock_timeout 30 mock_ecflow_client --msg mock_ecf_job: Job UNKNOWN failed"* ]] && \
        [[ "$output" == *"mock_timeout 30 mock_ssh my-ecflow-host echo"* ]] && \
        [[ "$output" == *">> $ECF_JOBOUT"* ]]; then
@@ -151,7 +181,7 @@ test_sendecf_yes() {
 }
 
 test_ecflow_log_no_ecf_jobout() {
-    setup
+    setup pbs
     export SENDECF="YES"
     export ECF_JOBOUT="/path/to/ecf.out"
 
@@ -167,7 +197,7 @@ test_ecflow_log_no_ecf_jobout() {
 }
 
 test_ecflow_log_no_ecf_host() {
-    setup
+    setup pbs
     export SENDECF="YES"
     export ECF_HOST="my-ecflow-host"
 
@@ -183,7 +213,7 @@ test_ecflow_log_no_ecf_host() {
 }
 
 test_ecflow_log_no_ecf_jobout_no_ecf_host() {
-    setup
+    setup pbs
     export SENDECF="YES"
 
     local output
@@ -205,7 +235,7 @@ test_kill_via_ecflow_when_no_pbs() {
 
     local output
     output=$($SCRIPT_UNDER_TEST 2>&1)
-    
+
     if [[ "$output" == *"mock_ecflow_client --kill=mock_ecf_job"* ]]; then
         pass "$FUNCNAME"
     else
@@ -235,12 +265,11 @@ test_kill_via_ecflow_no_ecf_name() {
 }
 
 test_kill_via_qdel_when_pbs_set() {
-    setup
-    export PBS_JOBID="12345.scheduler"
-    
+    setup pbs
+
     local output
     output=$($SCRIPT_UNDER_TEST 2>&1)
-    
+
     if [[ "$output" == *"mock_qdel 12345.scheduler"* ]] && [[ "$output" != *"mock_ecflow_client --kill"* ]]; then
         pass "$FUNCNAME"
     else
@@ -250,7 +279,8 @@ test_kill_via_qdel_when_pbs_set() {
 }
 
 test_kill_via_qdel_no_pbs_jobid() {
-    setup
+    setup pbs
+    unset PBS_JOBID
 
     local output
     output=$($SCRIPT_UNDER_TEST 2>&1)
@@ -258,6 +288,73 @@ test_kill_via_qdel_no_pbs_jobid() {
     if [[ "$output" == *"Could not find a scheduler command or job ID to kill the current job"* ]] && \
         [[ "$output" == *"KILLJOB = qdel"* ]] && \
         echo "$output" | grep -qE "^JOBID   = $" ; then
+        echo "$output"
+        pass "$FUNCNAME"
+    else
+        fail "$FUNCNAME" "Expected failure did not occur when JOBID is empty. Output: $output"
+    fi
+    teardown
+}
+
+test_kill_via_scancel_when_slurm_set() {
+    setup slurm
+    export JOBID="$SLURM_JOB_ID"
+
+    local output
+    output=$($SCRIPT_UNDER_TEST 2>&1)
+
+    if [[ "$output" == *"mock_scancel 67890"* ]] && [[ "$output" != *"mock_ecflow_client --kill"* ]]; then
+        pass "$FUNCNAME"
+    else
+        fail "$FUNCNAME" "Expected scancel call missing or ecflow called improperly. Output: $output"
+    fi
+    teardown
+}
+
+test_kill_via_scancel_no_slurm_job_id() {
+    setup slurm
+    unset SLURM_JOB_ID
+
+    local output
+    output=$($SCRIPT_UNDER_TEST 2>&1)
+
+    if [[ "$output" == *"Could not find a scheduler command or job ID to kill the current job"* ]] && \
+        [[ "$output" == *"KILLJOB = scancel"* ]] && \
+        echo "$output" | grep -qE "^JOBID   = $" ; then
+        echo "$output"
+        pass "$FUNCNAME"
+    else
+        fail "$FUNCNAME" "Expected failure did not occur when JOBID is empty. Output: $output"
+    fi
+    teardown
+}
+
+test_kill_via_bkill_when_lsf_set() {
+    setup lsf
+    export JOBID="$LSF_JOBID"
+
+    local output
+    output=$($SCRIPT_UNDER_TEST 2>&1)
+
+    if [[ "$output" == *"mock_bkill 54321"* ]] && [[ "$output" != *"mock_ecflow_client --kill"* ]]; then
+        pass "$FUNCNAME"
+    else
+        fail "$FUNCNAME" "Expected bkill call missing or ecflow called improperly. Output: $output"
+    fi
+    teardown
+}
+
+test_kill_via_bkill_no_lsf_job_id() {
+    setup lsf
+    unset LSF_JOBID
+
+    local output
+    output=$($SCRIPT_UNDER_TEST 2>&1)
+
+    if [[ "$output" == *"Could not find a scheduler command or job ID to kill the current job"* ]] && \
+        [[ "$output" == *"KILLJOB = bkill"* ]] && \
+        echo "$output" | grep -qE "^JOBID   = $" ; then
+        echo "$output"
         pass "$FUNCNAME"
     else
         fail "$FUNCNAME" "Expected failure did not occur when JOBID is empty. Output: $output"
@@ -287,8 +384,25 @@ test_ecflow_log_no_ecf_host
 test_ecflow_log_no_ecf_jobout_no_ecf_host
 test_kill_via_ecflow_when_no_pbs
 test_kill_via_ecflow_no_ecf_name
-test_kill_via_qdel_when_pbs_set
-test_kill_via_qdel_no_pbs_jobid
+# These tests will not work if qdel, scancel, or bkill are in the PATH, so skip if they are detected.
+# Test all cases if the commands are not found, otherwise only test the found commands.
+if command -v qdel &> /dev/null; then
+    test_kill_via_qdel_when_pbs_set
+    test_kill_via_qdel_no_pbs_jobid
+elif command -v scancel &> /dev/null; then
+    test_kill_via_scancel_when_slurm_set
+    test_kill_via_scancel_no_slurm_job_id
+elif command -v bkill &> /dev/null; then
+    test_kill_via_bkill_when_lsf_set
+    test_kill_via_bkill_no_lsf_job_id
+else
+    test_kill_via_qdel_when_pbs_set
+    test_kill_via_qdel_no_pbs_jobid
+    test_kill_via_scancel_when_slurm_set
+    test_kill_via_scancel_no_slurm_job_id
+    test_kill_via_bkill_when_lsf_set
+    test_kill_via_bkill_no_lsf_job_id
+fi
 
 echo "-------------------------------------------------------------"
 echo "Test Run Complete: $PASSED passed, $FAILED failed."
@@ -298,4 +412,4 @@ if [ "$FAILED" -ne 0 ]; then
     exit 1
 else
     exit 0
-fi 
+fi

--- a/ush/err_chk
+++ b/ush/err_chk
@@ -4,34 +4,58 @@
 #
 # ABSTRACT:  This script checks a return code in $err.  If $err=0
 # a message that the program completed is put in the job outputfile and
-# in a log file.  If $err != 0 then fail messages are put in job 
+# in a log file.  If $err != 0 then fail messages are put in job
 # output file and the job is terminated.
-# 
+#
 # USAGE:  To use this script one must export the following variables
 # to the script:  err, pgm, pgmout, jobid
 
-if [ -z "$err" ]; then err_exit "RETURN CODE NOT EXPORTED prior to running err_chk" ; exit ; fi
-if [ $err -eq 0 ]; then echo "$pgm completed cleanly" ; exit ; fi
+err=${err:-""}           # Return code from program
+pgm=${pgm:-""}           # Program name
+COREROOT=${COREROOT:-""} # Directory to copy core files to
+DATA=${DATA:-""}         # Working directory
+
+if [ -z "${err}" ]; then
+    err_exit "RETURN CODE NOT EXPORTED prior to running err_chk"
+    exit
+fi
+if [ "${err}" -eq 0 ]; then
+    echo "${pgm} completed cleanly"
+    exit
+fi
 
 #  If error return code is 139, then program segfaulted.
 #  Look for any core files, and save them to a directory in /ptmp
-if [ $err -eq 139 ]; then
-  if [ -z "$COREROOT" ]; then
-    >&2 echo "SegFault reported but \$COREROOT variable not set. Will not copy files."
-  else
-    >&2 echo "SegFault reported. Copying core files to ${COREROOT}"
-    cd $DATA
-    if [ -s core ]; then
-      mkdir -p ${COREROOT}
-      cp -p core ${COREROOT}/$pgm.$$.core
-    elif [ -s core.* ]; then
-      mkdir -p ${COREROOT}
-      cp -p core.* ${COREROOT}/
-    fi 
-    for coredir in `ls -d coredir.*`; do
-      mkdir -p ${COREROOT}/$coredir
-      cp -p ${coredir}/* ${COREROOT}/${coredir}/
-    done
-  fi
+if [ "${err}" -eq 139 ]; then
+    if [ -z "${COREROOT}" ]; then
+        >&2 echo "SegFault reported but \$COREROOT variable not set. Will not copy files."
+    else
+        >&2 echo "SegFault reported. Copying core files to ${COREROOT}"
+        if [ -z "${DATA}" ]; then
+            >&2 echo "  \$DATA variable not set. Cannot copy core files!"
+        else
+            if ! cd "${DATA}"; then
+                >&2 echo "  Cannot cd to DATA directory ${DATA}. Cannot copy core files!"
+                err_exit $@
+            fi
+            if [ -s core ]; then
+                mkdir -p "${COREROOT}"
+                cp -p core "${COREROOT}/${pgm}.$$.core"
+            else
+                core_list=$(find . -maxdepth 1 -type f -name "core.*")
+                for core_file in ${core_list}; do
+                    if [ -s "${core_file}" ]; then
+                        mkdir -p "${COREROOT}"
+                        cp -p "${core_file}" "${COREROOT}/"
+                    fi
+                done
+            fi
+            coredirs=$(find . -maxdepth 1 -type d -name "coredir.*")
+            for coredir in ${coredirs}; do
+                mkdir -p "${COREROOT}/${coredir}"
+                cp -p "${coredir}"/* "${COREROOT}/${coredir}/"
+            done
+        fi
+    fi
 fi
 err_exit $@

--- a/ush/err_exit
+++ b/ush/err_exit
@@ -19,7 +19,29 @@ ECF_NAME=${ECF_NAME:-""}   # Name of the ECF Job
 ECF_HOST=${ECF_HOST:-""}   # ecflow hostname
 ECF_JOBOUT=${ECF_JOBOUT:-""} # ecflow job output file
 JOBID=${JOBID:-$PBS_JOBID}   # Scheduler Job ID e.g. $PBS_JOBID, $SLURM_ID, etc
-KILLJOB=${KILLJOB:-qdel}     # Scheduler command to kill a job e.g. qdel, scancel, etc
+
+if [[ -z "${KILLJOB:-}" ]]; then
+    if [[ -n "${PBS_JOBID:-}" ]]; then
+        KILLJOB="qdel"
+    elif [[ -n "${SLURM_JOB_ID:-}" ]]; then
+        KILLJOB="scancel"
+    elif [[ -n "${LSB_JOBID:-}" ]]; then
+        KILLJOB="bkill"
+    else
+        # Check if qdel, scancel, or bkill commands are available in the PATH
+        if command -v qdel &> /dev/null; then
+            KILLJOB="qdel"
+        elif command -v scancel &> /dev/null; then
+            KILLJOB="scancel"
+        elif command -v bkill &> /dev/null; then
+            KILLJOB="bkill"
+        else
+            echo "WARNING: Could not determine job scheduler and KILLJOB variable is not set."
+            echo "         Continuing assuming that ecflow will be used to kill the job."
+            KILLJOB=""
+        fi
+    fi
+fi
 
 msg1=${*:-Job ${jobid} failed}
 if [[ -n "${pgm}" ]]; then

--- a/ush/err_exit
+++ b/ush/err_exit
@@ -113,7 +113,7 @@ else
     echo "JOBID   = ${JOBID}"
 fi
 
-if [[ ! -z "${SLURM_JOB_ID}" ]; then
+if [[ ! -z "${SLURM_JOB_ID}" ]]; then
     echo "----- waiting for ${SLURM_JOB_ID} to be killed -----"
     sleep 600
 fi

--- a/ush/err_exit
+++ b/ush/err_exit
@@ -2,70 +2,91 @@
 
 # SCRIPT NAME:  err_exit
 #
-# ABSTRACT:  This script is to be used when a fatal error or condition 
+# ABSTRACT:  This script is to be used when a fatal error or condition
 # has been reached and you want to terminate the job.
 #
 # USAGE:  To use this script one must export the following variables to the
 # script: jobid, SENDECF, pgm, pgmout, DATA. One can provide
 # a message for the logfile by passing it to the script as an argument.
 
-msg1=${@:-Job $jobid failed}
-if [ -n "$pgm" ]; then
-  msg1+=", ERROR IN $pgm"
+err=${err:-""}             # Return code from program
+pgm=${pgm:-""}             # Program name
+pgmout=${pgmout:-""}       # Program output file
+jobid=${jobid:-"UNKNOWN"}  # Job ID
+DATA=${DATA:-""}           # Working directory
+SENDECF=${SENDECF:-"NO"}   # Send message to ecflow
+ECF_NAME=${ECF_NAME:-""}   # Name of the ECF Job
+ECF_HOST=${ECF_HOST:-""}   # ecflow hostname
+ECF_JOBOUT=${ECF_JOBOUT:-""} # ecflow job output file
+JOBID=${JOBID:-$PBS_JOBID}   # Scheduler Job ID e.g. $PBS_JOBID, $SLURM_ID, etc
+KILLJOB=${KILLJOB:-qdel}     # Scheduler command to kill a job e.g. qdel, scancel, etc
+
+msg1=${*:-Job ${jobid} failed}
+if [[ -n "${pgm}" ]]; then
+    msg1+=", ERROR IN ${pgm}"
 fi
-if [ -n "$err" ]; then
-  msg1+=" RETURN CODE $err"
+if [[ -n "${err}" ]]; then
+    msg1+=" RETURN CODE ${err}"
 fi
 
 msg2="
 -------------------------------------------------------------
--- FATAL ERROR: $msg1
--- ABNORMAL EXIT at $(date) on $HOSTNAME
+-- FATAL ERROR: ${msg1}
+-- ABNORMAL EXIT at $(date) on ${HOSTNAME}
 -------------------------------------------------------------
 "
 
->&2 echo "$msg2"
+>&2 echo "${msg2}"
 
 # list loaded modules
 module list
 >&2 echo ""
 
->&2 echo "$msg1"
+>&2 echo "${msg1}"
 
 # list files in temporary working directory
-if [ -n "$DATA" ]; then
-  >&2 echo $DATA
-  >&2 ls -ltr $DATA
+if [[ -n "${DATA}" ]]; then
+    >&2 echo "${DATA}"
+    >&2 ls -ltr "${DATA}"
 else
-  >&2 echo "WARNING: DATA variable not defined"
+    >&2 echo "WARNING: DATA variable not defined"
 fi
 
 # save standard output
-if [ -n "$pgmout" ]; then
-  if [ -s errfile ]; then
-    echo "----- contents of errfile -----" >> $pgmout
-    cat errfile >> $pgmout
-  fi
-  >&2 cat $pgmout
-elif [ -s errfile ]; then
-  >&2 cat errfile
+if [[ -n "${pgmout}" ]]; then
+    if [[ -s errfile ]]; then
+        echo "----- contents of errfile -----" >> "${pgmout}"
+        cat errfile >> "${pgmout}"
+    fi
+    >&2 cat "${pgmout}"
+elif [[ -s errfile ]]; then
+    >&2 cat errfile
 fi
 
 # Write to ecflow log:
-if [ "$SENDECF" = "YES" ]; then
-  timeout 30 ecflow_client --msg "$ECF_NAME: $msg1"
-  timeout 30 ssh $ECF_HOST "echo \"$msg2\" >> ${ECF_JOBOUT:?}"
+if [[ "${SENDECF}" == "YES" ]]; then
+    timeout 30 ecflow_client --msg "${ECF_NAME}: ${msg1}"
+    if [[ -z "${ECF_JOBOUT}" || "${ECF_HOST}" == "" ]]; then
+        echo "FATAL ERROR Unable to write to ecflow server as either ECF_HOST or ECF_JOBOUT are undefined!!"
+    else
+        timeout 30 ssh "${ECF_HOST}" "echo \"${msg2}\" >> ${ECF_JOBOUT}"
+    fi
 fi
 
-# KILL THE JOB:
-if [ "$SENDECF" = "YES" ]; then
-  ecflow_client --kill=${ECF_NAME:?}
-fi
-
-if [ ! -z $PBS_JOBID ]; then
-  qdel $PBS_JOBID
-elif [ ! -z $SLURM_JOB_ID ]; then
-  scancel $SLURM_JOB_ID
-  echo "----- waiting for $SLURM_JOB_ID to be killed -----"
-  sleep 600
+# KILL THE JOB VIA ECFLOW:
+if [[ "${SENDECF}" == "YES" ]]; then
+    if [[ -z "${ECF_NAME}" ]]; then
+        echo "FATAL ERROR Unable to kill ecflow job as ECF_NAME variable is not set!!"
+    else
+        echo "Killing the job via ecflow kill"
+        ecflow_client --kill="${ECF_NAME}"
+    fi
+# KILL THE JOB VIA JOB SCHEDULER COMMAND:
+elif [[ -n "${KILLJOB}" && -n "${JOBID}" ]]; then
+    echo "Killing the job via ${KILLJOB}"
+    ${KILLJOB} ${JOBID}
+else
+    echo "Could not find a scheduler command or job ID to kill the current job"
+    echo "KILLJOB = ${KILLJOB}"
+    echo "JOBID   = ${JOBID}"
 fi

--- a/ush/err_exit
+++ b/ush/err_exit
@@ -115,5 +115,6 @@ fi
 
 if [[ ! -z "${SLURM_JOB_ID}" ]]; then
     echo "----- waiting for ${SLURM_JOB_ID} to be killed -----"
-    sleep 600
+    sleep_time=${SLURM_SLEEP:-600}
+    sleep "${sleep_time}"
 fi

--- a/ush/err_exit
+++ b/ush/err_exit
@@ -90,3 +90,8 @@ else
     echo "KILLJOB = ${KILLJOB}"
     echo "JOBID   = ${JOBID}"
 fi
+
+if [[ ! -z "${SLURM_JOB_ID}" ]; then
+    echo "----- waiting for ${SLURM_JOB_ID} to be killed -----"
+    sleep 600
+fi

--- a/ush/mail.py
+++ b/ush/mail.py
@@ -56,7 +56,7 @@ def send(subject, message_body, to_address=default_recipient, cc_address=None, b
     ecFlow_task_path = getenv('ECF_NAME')
     if ecFlow_task_path:
         job_info.append(("ecFlow Task", ecFlow_task_path))
-    if getenv('ECF_RID'):
+    if getenv('PBS_JOBNAME'):
         try:
             stdout_file = check_output("qstat -fwx {0} | grep Output_Path".format(getenv('ECF_RID')), shell=True).decode().split(":")[1]
         except:


### PR DESCRIPTION
This primarily adds updates to `err_exit` and `err_chk` to enable the use of stringent error checking (`set -eu -o pipefail`). It also adds tests for err_exit.

One important addition to err_exit with this PR is the addition of the `KILLJOB` environment variable. This variable needs to be set in the target workflow to tell `err_exit` what command to use to kill a job. For PBS, this is `qdel`. For Slurm it is `scancel`. For LSF, it is `bkill`.

These changes are currently in para testing on WCOSS2.

NCO PR https://github.com/NCO-HPC/prod_util/pull/13